### PR TITLE
fixes issue 15

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -609,7 +609,7 @@ $(function() {
 			createCard( 
 				'card' + uniqueID,
 				'',
-			 	58, 460,
+			 	58, $('div.board-outline').height(),// hack - not a great way to get the new card coordinates, but most consistant ATM
 			   rotation,
 			   randomCardColour());
 		});


### PR DESCRIPTION
- using the div.board-outline height seems to be the most accurate .offset() on a floating element didn't return the right results, I assume a margin/padding/position issue is to blame but this works too.
