### PR TITLE
I set the default port

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ app.post('/edit-column', function(req, res) {
 	res.send(req.body.value);
 });
 
-app.listen(process.argv[2]);
+app.listen(process.argv[2] || 8124);
 
 //I limit the number of potential transports because xhr was causing trouble
 //with frequent disconnects


### PR DESCRIPTION
Something like [node-supervisor](https://github.com/isaacs/node-supervisor) can't work well with non-optional argument(s). So I add this(8124 is just a choice).

I added only 8 characters. Not sure should it be a pull request.
