### PR TITLE
Added missing method for mongodb

### DIFF
--- a/lib/data/mongodb.js
+++ b/lib/data/mongodb.js
@@ -150,6 +150,25 @@ db.prototype = {
 			{name:room},
 			{$set:doc}
 		);
+	},
+	getBoardSize: function(room, callback) {
+		this.rooms.findOne(
+			{name:room},
+			function(err, room) {
+				if(room) {
+					callback(room.size);
+				} else {
+					callback();
+				}
+			}
+		);		
+	},
+	setBoardSize: function(room, size) {
+		this.room.findOne({name:room})
+		this.rooms.update(
+			{name:room},
+			{$set:{'size':size}}
+		);
 	}
 };
 exports.db = db;


### PR DESCRIPTION
I've noticed that getBoardSize and setBoardSize where missing for mongodb.
