### PR TITLE
prompt confirmation to delete card unless shift-click

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -246,10 +246,12 @@ function drawNewCard(id, text, x, y, rot, colour, sticker, animationspeed)
 	);
 	
 	card.children('.delete-card-icon').click(
-		function(){
-			$("#" + id).remove();
-			//notify server of delete
-			sendAction( 'deleteCard' , { 'id': id });
+		function(e){
+			if (e.shiftKey || confirm('Delete card?')) {
+				$("#" + id).remove();
+				//notify server of delete
+				sendAction( 'deleteCard' , { 'id': id });
+			}
 		}
 	);
 	


### PR DESCRIPTION
It's easy to accidentally delete a card so I've added a confirmation prompt. Of course, the prompt can be obnoxious when one needs to delete many cards so it can be suppressed with shift+click
