### PR TITLE
Allow subpaths

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -21,7 +21,7 @@ body {
 	-khtml-user-select: none;
 	-webkit-user-select: none;
 
-	background-image: url('/css/bg/concrete_wall_2_2.png');
+	background-image: url('bg/concrete_wall_2_2.png');
 
 }
 
@@ -127,7 +127,7 @@ width: 16px; height: 16px;
 	vertical-align: top;
 	height: 100%;
 	xopacity: 1;
-	background-image: url('/images/green-board-line.png');
+	background-image: url('../images/green-board-line.png');
 	background-repeat: repeat-y;
 	background-position: left top;
 }
@@ -311,43 +311,43 @@ xopacity: .5;
 
 
 #sticker-red {
-	background-image: url('/images/stickers/sticker-red.png');
+	background-image: url('../images/stickers/sticker-red.png');
 }
 #sticker-blue {
-	background-image: url('/images/stickers/sticker-blue.png');
+	background-image: url('../images/stickers/sticker-blue.png');
 }
 #sticker-yellow {
-	background-image: url('/images/stickers/sticker-yellow.png');
+	background-image: url('../images/stickers/sticker-yellow.png');
 }
 #sticker-green {
-	background-image: url('/images/stickers/sticker-green.png');
+	background-image: url('../images/stickers/sticker-green.png');
 }
 #sticker-pink {
-	background-image: url('/images/stickers/sticker-pink.png');
+	background-image: url('../images/stickers/sticker-pink.png');
 }
 #sticker-lightblue {
-	background-image: url('/images/stickers/sticker-lightblue.png');
+	background-image: url('../images/stickers/sticker-lightblue.png');
 }
 #sticker-orange {
-	background-image: url('/images/stickers/sticker-orange.png');
+	background-image: url('../images/stickers/sticker-orange.png');
 }
 #sticker-purple {
-	background-image: url('/images/stickers/sticker-purple.png');
+	background-image: url('../images/stickers/sticker-purple.png');
 }
 #sticker-gold {
-	background-image: url('/images/stickers/sticker-gold.png');
+	background-image: url('../images/stickers/sticker-gold.png');
 }
 #sticker-silverstar {
-	background-image: url('/images/stickers/sticker-silverstar.png');
+	background-image: url('../images/stickers/sticker-silverstar.png');
 }
 #sticker-bluestar {
-	background-image: url('/images/stickers/sticker-bluestar.png');
+	background-image: url('../images/stickers/sticker-bluestar.png');
 }
 #sticker-redstar {
-	background-image: url('/images/stickers/sticker-redstar.png');
+	background-image: url('../images/stickers/sticker-redstar.png');
 }
 #addsticker {
-	background-image: url('/images/icons/iconic/raster/black/plus_8x8.png');
+	background-image: url('../images/icons/iconic/raster/black/plus_8x8.png');
 	background-position: 2px 2px;
 	opacity: 0.3;
 
@@ -360,7 +360,7 @@ xopacity: .5;
 	opacity: 0.7;
 }
 #nosticker {
-	background-image: url('/images/stickers/sticker-deletestar.png');
+	background-image: url('../images/stickers/sticker-deletestar.png');
 }
 
 #sticker-nostar {
@@ -374,73 +374,73 @@ xopacity: .5;
 }
 
 /*.sticker-red {
-	background-image: url('/images/stickers/sticker-red.png');
+	background-image: url('../images/stickers/sticker-red.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-blue {
-	background-image: url('/images/stickers/sticker-blue.png');
+	background-image: url('../images/stickers/sticker-blue.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-yellow {
-	background-image: url('/images/stickers/sticker-yellow.png');
+	background-image: url('../images/stickers/sticker-yellow.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-green {
-	background-image: url('/images/stickers/sticker-green.png');
+	background-image: url('../images/stickers/sticker-green.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-gold {
-	background-image: url('/images/stickers/sticker-gold.png');
+	background-image: url('../images/stickers/sticker-gold.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-bluestar {
-	background-image: url('/images/stickers/sticker-bluestar.png');
+	background-image: url('../images/stickers/sticker-bluestar.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-silverstar {
-	background-image: url('/images/stickers/sticker-silverstar.png');
+	background-image: url('../images/stickers/sticker-silverstar.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-redstar {
-	background-image: url('/images/stickers/sticker-redstar.png');
+	background-image: url('../images/stickers/sticker-redstar.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-pink {
-	background-image: url('/images/stickers/sticker-pink.png');
+	background-image: url('../images/stickers/sticker-pink.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-orange {
-	background-image: url('/images/stickers/sticker-orange.png');
+	background-image: url('../images/stickers/sticker-orange.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-lightblue {
-	background-image: url('/images/stickers/sticker-lightblue.png');
+	background-image: url('../images/stickers/sticker-lightblue.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }
 
 .sticker-purple {
-	background-image: url('/images/stickers/sticker-purple.png');
+	background-image: url('../images/stickers/sticker-purple.png');
 	background-repeat: no-repeat;
 	background-position: right bottom;
 }*/
@@ -594,14 +594,14 @@ img {
 
 
 /* states and images */
-.ui-icon { width: 16px; height: 16px; background-image: url(images/ui-icons_222222_256x240.png); }
-.ui-widget-content .ui-icon {background-image: url(images/ui-icons_222222_256x240.png); }
-.ui-widget-header .ui-icon {background-image: url(images/ui-icons_222222_256x240.png); }
-.ui-state-default .ui-icon { background-image: url(images/ui-icons_888888_256x240.png); }
-.ui-state-hover .ui-icon, .ui-state-focus .ui-icon {background-image: url(images/ui-icons_454545_256x240.png); }
-.ui-state-active .ui-icon {background-image: url(images/ui-icons_454545_256x240.png); }
-.ui-state-highlight .ui-icon {background-image: url(images/ui-icons_2e83ff_256x240.png); }
-.ui-state-error .ui-icon, .ui-state-error-text .ui-icon {background-image: url(images/ui-icons_cd0a0a_256x240.png); }
+.ui-icon { width: 16px; height: 16px; background-image: url(../images/ui-icons_222222_256x240.png); }
+.ui-widget-content .ui-icon {background-image: url(../images/ui-icons_222222_256x240.png); }
+.ui-widget-header .ui-icon {background-image: url(../images/ui-icons_222222_256x240.png); }
+.ui-state-default .ui-icon { background-image: url(../images/ui-icons_888888_256x240.png); }
+.ui-state-hover .ui-icon, .ui-state-focus .ui-icon {background-image: url(../images/ui-icons_454545_256x240.png); }
+.ui-state-active .ui-icon {background-image: url(../images/ui-icons_454545_256x240.png); }
+.ui-state-highlight .ui-icon {background-image: url(../images/ui-icons_2e83ff_256x240.png); }
+.ui-state-error .ui-icon, .ui-state-error-text .ui-icon {background-image: url(../images/ui-icons_cd0a0a_256x240.png); }
 
 
 .ui-resizable { position: relative;}

--- a/client/lib/jquery-ui/development-bundle/demos/demos.css
+++ b/client/lib/jquery-ui/development-bundle/demos/demos.css
@@ -35,7 +35,7 @@ body {
 }
 
 .layout-grid td.demos {
-	background: url('/images/demos_bg.jpg') no-repeat;
+	background: url('../images/demos_bg.jpg') no-repeat;
 	height: 337px;
 	overflow: hidden;
 }
@@ -153,12 +153,12 @@ eventually we should convert the font sizes to ems -- using px for now to minimi
 #demo-config-menu li a:hover,
 #demo-config-menu li a:active { background-color:#f6f6f6; }
 
-#demo-config-menu li.demo-config-on { background: url(images/demo-config-on-tile.gif) repeat-x left center; }
+#demo-config-menu li.demo-config-on { background: url(../images/demo-config-on-tile.gif) repeat-x left center; }
 
 #demo-config-menu li.demo-config-on a:link,
 #demo-config-menu li.demo-config-on a:visited,
 #demo-config-menu li.demo-config-on a:hover,
-#demo-config-menu li.demo-config-on a:active { background: url(images/demo-config-on.gif) no-repeat left; padding-left:18px; color:#fff; border:0; margin-left:-10px; margin-top: 0px; margin-bottom: 0px; }
+#demo-config-menu li.demo-config-on a:active { background: url(../images/demo-config-on.gif) no-repeat left; padding-left:18px; color:#fff; border:0; margin-left:-10px; margin-top: 0px; margin-bottom: 0px; }
 
 #demo-source, #demo-notes {
 	clear: both;
@@ -179,12 +179,12 @@ code, pre { padding:8px 0 8px 20px ; font-size: 1.2em; line-height:130%;  }
 #demo-source a.source-open:link,
 #demo-source a.source-open:visited,
 #demo-source a.source-open:hover,
-#demo-source a.source-open:active { background-image: url(images/demo-spindown-open.gif); }
+#demo-source a.source-open:active { background-image: url(../images/demo-spindown-open.gif); }
 
 #demo-source a.source-closed:link,
 #demo-source a.source-closed:visited,
 #demo-source a.source-closed:hover,
-#demo-source a.source-closed:active { background-image: url(images/demo-spindown-closed.gif); }
+#demo-source a.source-closed:active { background-image: url(../images/demo-spindown-closed.gif); }
 
 div.demo {
 	padding:12px;
@@ -216,24 +216,24 @@ div.demo-description {
 ----------------------------------*/
 #widget-docs .ui-widget { font-family: Trebuchet MS,Verdana,Arial,sans-serif; font-size: 1em; }
 #widget-docs .ui-widget input, #widget-docs .ui-widget select, #widget-docs .ui-widget textarea, #widget-docs .ui-widget button { font-family: Trebuchet MS,Verdana,Arial,sans-serif; font-size: 1em; }
-#widget-docs .ui-widget-header { border: 1px solid #ffffff; background: #464646 url(images/464646_40x100_textures_01_flat_100.png) 50% 50% repeat-x; color: #ffffff; font-weight: bold; }
+#widget-docs .ui-widget-header { border: 1px solid #ffffff; background: #464646 url(../images/464646_40x100_textures_01_flat_100.png) 50% 50% repeat-x; color: #ffffff; font-weight: bold; }
 #widget-docs .ui-widget-header a { color: #ffffff; }
-#widget-docs .ui-widget-content { border: 1px solid #ffffff; background: #ffffff url(images/ffffff_40x100_textures_01_flat_75.png) 50% 50% repeat-x; color: #222222; }
+#widget-docs .ui-widget-content { border: 1px solid #ffffff; background: #ffffff url(../images/ffffff_40x100_textures_01_flat_75.png) 50% 50% repeat-x; color: #222222; }
 #widget-docs .ui-widget-content a { color: #222222; }
 
 /* Interaction states
 ----------------------------------*/
-#widget-docs .ui-state-default, #widget-docs .ui-widget-content #widget-docs .ui-state-default { border: 1px solid #666666; background: #555555 url(images/555555_40x100_textures_03_highlight_soft_75.png) 50% 50% repeat-x; font-weight: normal; color: #ffffff; outline: none; }
+#widget-docs .ui-state-default, #widget-docs .ui-widget-content #widget-docs .ui-state-default { border: 1px solid #666666; background: #555555 url(../images/555555_40x100_textures_03_highlight_soft_75.png) 50% 50% repeat-x; font-weight: normal; color: #ffffff; outline: none; }
 #widget-docs .ui-state-default a { color: #ffffff; text-decoration: none; outline: none; }
-#widget-docs .ui-state-hover, #widget-docs .ui-widget-content #widget-docs .ui-state-hover, #widget-docs .ui-state-focus, #widget-docs .ui-widget-content #widget-docs .ui-state-focus { border: 1px solid #666666; background: #444444 url(images/444444_40x100_textures_03_highlight_soft_60.png) 50% 50% repeat-x; font-weight: normal; color: #ffffff; outline: none; }
+#widget-docs .ui-state-hover, #widget-docs .ui-widget-content #widget-docs .ui-state-hover, #widget-docs .ui-state-focus, #widget-docs .ui-widget-content #widget-docs .ui-state-focus { border: 1px solid #666666; background: #444444 url(../images/444444_40x100_textures_03_highlight_soft_60.png) 50% 50% repeat-x; font-weight: normal; color: #ffffff; outline: none; }
 #widget-docs .ui-state-hover a { color: #ffffff; text-decoration: none; outline: none; }
-#widget-docs .ui-state-active, #widget-docs .ui-widget-content #widget-docs .ui-state-active { border: 1px solid #666666; background: #ffffff url(images/ffffff_40x100_textures_01_flat_65.png) 50% 50% repeat-x; font-weight: normal; color: #F6921E; outline: none; }
+#widget-docs .ui-state-active, #widget-docs .ui-widget-content #widget-docs .ui-state-active { border: 1px solid #666666; background: #ffffff url(../images/ffffff_40x100_textures_01_flat_65.png) 50% 50% repeat-x; font-weight: normal; color: #F6921E; outline: none; }
 #widget-docs .ui-state-active a { color: #F6921E; outline: none; text-decoration: none; }
 
 /* Interaction Cues
 ----------------------------------*/
-#widget-docs .ui-state-highlight, #widget-docs .ui-widget-content #widget-docs .ui-state-highlight {border: 1px solid #fcefa1; background: #fbf9ee url(images/fbf9ee_40x100_textures_02_glass_55.png) 50% 50% repeat-x; color: #363636; }
-#widget-docs .ui-state-error, #widget-docs .ui-widget-content #widget-docs .ui-state-error {border: 1px solid #cd0a0a; background: #fef1ec url(images/fef1ec_40x100_textures_05_inset_soft_95.png) 50% bottom repeat-x; color: #cd0a0a; }
+#widget-docs .ui-state-highlight, #widget-docs .ui-widget-content #widget-docs .ui-state-highlight {border: 1px solid #fcefa1; background: #fbf9ee url(../images/fbf9ee_40x100_textures_02_glass_55.png) 50% 50% repeat-x; color: #363636; }
+#widget-docs .ui-state-error, #widget-docs .ui-widget-content #widget-docs .ui-state-error {border: 1px solid #cd0a0a; background: #fef1ec url(../images/fef1ec_40x100_textures_05_inset_soft_95.png) 50% bottom repeat-x; color: #cd0a0a; }
 #widget-docs .ui-state-error-text, #widget-docs .ui-widget-content #widget-docs .ui-state-error-text { color: #cd0a0a; }
 #widget-docs .ui-state-disabled, #widget-docs .ui-widget-content #widget-docs .ui-state-disabled { opacity: .35; filter:Alpha(Opacity=35); background-image: none; }
 #widget-docs .ui-priority-primary, #widget-docs .ui-widget-content #widget-docs .ui-priority-primary { font-weight: bold; }
@@ -243,14 +243,14 @@ div.demo-description {
 ----------------------------------*/
 
 /* states and images */
-#demo-frame-wrapper .ui-icon, #widget-docs .ui-icon { width: 16px; height: 16px; background-image: url(images/222222_256x240_icons_icons.png); }
-#widget-docs .ui-widget-content .ui-icon {background-image: url(images/222222_256x240_icons_icons.png); }
-#widget-docs .ui-widget-header .ui-icon {background-image: url(images/222222_256x240_icons_icons.png); }
-#widget-docs .ui-state-default .ui-icon { background-image: url(images/888888_256x240_icons_icons.png); }
-#widget-docs .ui-state-hover .ui-icon, #widget-docs .ui-state-focus .ui-icon {background-image: url(images/454545_256x240_icons_icons.png); }
-#widget-docs .ui-state-active .ui-icon {background-image: url(images/454545_256x240_icons_icons.png); }
-#widget-docs .ui-state-highlight .ui-icon {background-image: url(images/2e83ff_256x240_icons_icons.png); }
-#widget-docs .ui-state-error .ui-icon, #widget-docs .ui-state-error-text .ui-icon {background-image: url(images/cd0a0a_256x240_icons_icons.png); }
+#demo-frame-wrapper .ui-icon, #widget-docs .ui-icon { width: 16px; height: 16px; background-image: url(../images/222222_256x240_icons_icons.png); }
+#widget-docs .ui-widget-content .ui-icon {background-image: url(../images/222222_256x240_icons_icons.png); }
+#widget-docs .ui-widget-header .ui-icon {background-image: url(../images/222222_256x240_icons_icons.png); }
+#widget-docs .ui-state-default .ui-icon { background-image: url(../images/888888_256x240_icons_icons.png); }
+#widget-docs .ui-state-hover .ui-icon, #widget-docs .ui-state-focus .ui-icon {background-image: url(../images/454545_256x240_icons_icons.png); }
+#widget-docs .ui-state-active .ui-icon {background-image: url(../images/454545_256x240_icons_icons.png); }
+#widget-docs .ui-state-highlight .ui-icon {background-image: url(../images/2e83ff_256x240_icons_icons.png); }
+#widget-docs .ui-state-error .ui-icon, #widget-docs .ui-state-error-text .ui-icon {background-image: url(../images/cd0a0a_256x240_icons_icons.png); }
 
 
 /* Misc visuals
@@ -268,8 +268,8 @@ div.demo-description {
 #widget-docs .ui-corner-all { -moz-border-radius: 4px; -webkit-border-radius: 4px; }
 
 /* Overlays */
-#widget-docs .ui-widget-overlay { background: #aaaaaa url(images/aaaaaa_40x100_textures_01_flat_0.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); }
-#widget-docs .ui-widget-shadow { margin: -8px 0 0 -8px; padding: 8px; background: #aaaaaa url(images/aaaaaa_40x100_textures_01_flat_0.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); -moz-border-radius: 8px; -webkit-border-radius: 8px; }
+#widget-docs .ui-widget-overlay { background: #aaaaaa url(../images/aaaaaa_40x100_textures_01_flat_0.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); }
+#widget-docs .ui-widget-shadow { margin: -8px 0 0 -8px; padding: 8px; background: #aaaaaa url(../images/aaaaaa_40x100_textures_01_flat_0.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); -moz-border-radius: 8px; -webkit-border-radius: 8px; }
 
 /*
 ----------------------------------*/
@@ -301,10 +301,10 @@ div.demo-description {
 .docs-list .param-header { float:left; clear:left; width:100%; padding:8px 0; border-top:1px solid #eee; }
 #widget-docs .param-header h3, #widget-docs .param-header p { margin:0; float:left; }
 #widget-docs .param-header h3 { width:50%; }
-#widget-docs .param-header h3 span { background: url(images/demo-spindown-closed.gif) no-repeat left; padding-left:13px; }
-#widget-docs .param-open .param-header h3 span { background: url(images/demo-spindown-open.gif) no-repeat left; }
+#widget-docs .param-header h3 span { background: url(../images/demo-spindown-closed.gif) no-repeat left; padding-left:13px; }
+#widget-docs .param-open .param-header h3 span { background: url(../images/demo-spindown-open.gif) no-repeat left; }
 #widget-docs .param-header p { width:24%; }
-#widget-docs .param-header p.param-type span { background: url(images/icon-docs-info.gif) no-repeat left; cursor:pointer; border-bottom:1px dashed #ccc; padding-left:15px; }
+#widget-docs .param-header p.param-type span { background: url(../images/icon-docs-info.gif) no-repeat left; cursor:pointer; border-bottom:1px dashed #ccc; padding-left:15px; }
 
 .param-details { padding-left:13px; }
 .param-args { margin:0 0 1.5em; border-top:1px dotted #ccc;}

--- a/client/lib/jquery-ui/development-bundle/themes/smoothness/jquery.ui.theme.css
+++ b/client/lib/jquery-ui/development-bundle/themes/smoothness/jquery.ui.theme.css
@@ -18,26 +18,26 @@
 .ui-widget { font-family: Verdana,Arial,sans-serif; font-size: 1.1em; }
 .ui-widget .ui-widget { font-size: 1em; }
 .ui-widget input, .ui-widget select, .ui-widget textarea, .ui-widget button { font-family: Verdana,Arial,sans-serif; font-size: 1em; }
-.ui-widget-content { border: 1px solid #aaaaaa; background: #ffffff url(images/ui-bg_flat_75_ffffff_40x100.png) 50% 50% repeat-x; color: #222222; }
+.ui-widget-content { border: 1px solid #aaaaaa; background: #ffffff url(../images/ui-bg_flat_75_ffffff_40x100.png) 50% 50% repeat-x; color: #222222; }
 .ui-widget-content a { color: #222222; }
-.ui-widget-header { border: 1px solid #aaaaaa; background: #cccccc url(images/ui-bg_highlight-soft_75_cccccc_1x100.png) 50% 50% repeat-x; color: #222222; font-weight: bold; }
+.ui-widget-header { border: 1px solid #aaaaaa; background: #cccccc url(../images/ui-bg_highlight-soft_75_cccccc_1x100.png) 50% 50% repeat-x; color: #222222; font-weight: bold; }
 .ui-widget-header a { color: #222222; }
 
 /* Interaction states
 ----------------------------------*/
-.ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default { border: 1px solid #d3d3d3; background: #e6e6e6 url(images/ui-bg_glass_75_e6e6e6_1x400.png) 50% 50% repeat-x; font-weight: normal; color: #555555; }
+.ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default { border: 1px solid #d3d3d3; background: #e6e6e6 url(../images/ui-bg_glass_75_e6e6e6_1x400.png) 50% 50% repeat-x; font-weight: normal; color: #555555; }
 .ui-state-default a, .ui-state-default a:link, .ui-state-default a:visited { color: #555555; text-decoration: none; }
-.ui-state-hover, .ui-widget-content .ui-state-hover, .ui-widget-header .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus { border: 1px solid #999999; background: #dadada url(images/ui-bg_glass_75_dadada_1x400.png) 50% 50% repeat-x; font-weight: normal; color: #212121; }
+.ui-state-hover, .ui-widget-content .ui-state-hover, .ui-widget-header .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus { border: 1px solid #999999; background: #dadada url(../images/ui-bg_glass_75_dadada_1x400.png) 50% 50% repeat-x; font-weight: normal; color: #212121; }
 .ui-state-hover a, .ui-state-hover a:hover { color: #212121; text-decoration: none; }
-.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active { border: 1px solid #aaaaaa; background: #ffffff url(images/ui-bg_glass_65_ffffff_1x400.png) 50% 50% repeat-x; font-weight: normal; color: #212121; }
+.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active { border: 1px solid #aaaaaa; background: #ffffff url(../images/ui-bg_glass_65_ffffff_1x400.png) 50% 50% repeat-x; font-weight: normal; color: #212121; }
 .ui-state-active a, .ui-state-active a:link, .ui-state-active a:visited { color: #212121; text-decoration: none; }
 .ui-widget :active { outline: none; }
 
 /* Interaction Cues
 ----------------------------------*/
-.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight  {border: 1px solid #fcefa1; background: #fbf9ee url(images/ui-bg_glass_55_fbf9ee_1x400.png) 50% 50% repeat-x; color: #363636; }
+.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight  {border: 1px solid #fcefa1; background: #fbf9ee url(../images/ui-bg_glass_55_fbf9ee_1x400.png) 50% 50% repeat-x; color: #363636; }
 .ui-state-highlight a, .ui-widget-content .ui-state-highlight a,.ui-widget-header .ui-state-highlight a { color: #363636; }
-.ui-state-error, .ui-widget-content .ui-state-error, .ui-widget-header .ui-state-error {border: 1px solid #cd0a0a; background: #fef1ec url(images/ui-bg_glass_95_fef1ec_1x400.png) 50% 50% repeat-x; color: #cd0a0a; }
+.ui-state-error, .ui-widget-content .ui-state-error, .ui-widget-header .ui-state-error {border: 1px solid #cd0a0a; background: #fef1ec url(../images/ui-bg_glass_95_fef1ec_1x400.png) 50% 50% repeat-x; color: #cd0a0a; }
 .ui-state-error a, .ui-widget-content .ui-state-error a, .ui-widget-header .ui-state-error a { color: #cd0a0a; }
 .ui-state-error-text, .ui-widget-content .ui-state-error-text, .ui-widget-header .ui-state-error-text { color: #cd0a0a; }
 .ui-priority-primary, .ui-widget-content .ui-priority-primary, .ui-widget-header .ui-priority-primary { font-weight: bold; }
@@ -47,15 +47,15 @@
 /* Icons
 ----------------------------------*/
 
-/* states and images */
-.ui-icon { width: 16px; height: 16px; background-image: url(images/ui-icons_222222_256x240.png); }
-.ui-widget-content .ui-icon {background-image: url(images/ui-icons_222222_256x240.png); }
-.ui-widget-header .ui-icon {background-image: url(images/ui-icons_222222_256x240.png); }
-.ui-state-default .ui-icon { background-image: url(images/ui-icons_888888_256x240.png); }
-.ui-state-hover .ui-icon, .ui-state-focus .ui-icon {background-image: url(images/ui-icons_454545_256x240.png); }
-.ui-state-active .ui-icon {background-image: url(images/ui-icons_454545_256x240.png); }
-.ui-state-highlight .ui-icon {background-image: url(images/ui-icons_2e83ff_256x240.png); }
-.ui-state-error .ui-icon, .ui-state-error-text .ui-icon {background-image: url(images/ui-icons_cd0a0a_256x240.png); }
+/* states and ../images */
+.ui-icon { width: 16px; height: 16px; background-image: url(../images/ui-icons_222222_256x240.png); }
+.ui-widget-content .ui-icon {background-image: url(../images/ui-icons_222222_256x240.png); }
+.ui-widget-header .ui-icon {background-image: url(../images/ui-icons_222222_256x240.png); }
+.ui-state-default .ui-icon { background-image: url(../images/ui-icons_888888_256x240.png); }
+.ui-state-hover .ui-icon, .ui-state-focus .ui-icon {background-image: url(../images/ui-icons_454545_256x240.png); }
+.ui-state-active .ui-icon {background-image: url(../images/ui-icons_454545_256x240.png); }
+.ui-state-highlight .ui-icon {background-image: url(../images/ui-icons_2e83ff_256x240.png); }
+.ui-state-error .ui-icon, .ui-state-error-text .ui-icon {background-image: url(../images/ui-icons_cd0a0a_256x240.png); }
 
 /* positioning */
 .ui-icon-carat-1-n { background-position: 0 0; }
@@ -250,5 +250,5 @@
 .ui-corner-all { -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px; }
 
 /* Overlays */
-.ui-widget-overlay { background: #aaaaaa url(images/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); }
-.ui-widget-shadow { margin: -8px 0 0 -8px; padding: 8px; background: #aaaaaa url(images/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); -moz-border-radius: 8px; -webkit-border-radius: 8px; border-radius: 8px; }
+.ui-widget-overlay { background: #aaaaaa url(../images/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); }
+.ui-widget-shadow { margin: -8px 0 0 -8px; padding: 8px; background: #aaaaaa url(../images/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x; opacity: .30;filter:Alpha(Opacity=30); -moz-border-radius: 8px; -webkit-border-radius: 8px; border-radius: 8px; }

--- a/client/script.js
+++ b/client/script.js
@@ -5,7 +5,8 @@ var currentTheme = "bigcards";
 var boardInitialized = false;
 var keyTrap = null;
 
-var socket = io.connect();
+var baseurl = location.pathname.substring(0, location.pathname.lastIndexOf('/'));
+var socket = io.connect({path: baseurl + "/socket.io"});
 
 //an action has happened, send it to the
 //server
@@ -23,11 +24,11 @@ function sendAction(a, d) {
 socket.on('connect', function() {
     //console.log('successful socket.io connect');
 
-    //let the path be the room name
-    var path = location.pathname;
+    //let the final part of the path be the room name
+    var room = location.pathname.substring(location.pathname.lastIndexOf('/'));
 
     //imediately join the room which will trigger the initializations
-    sendAction('joinRoom', path);
+    sendAction('joinRoom', room);
 });
 
 socket.on('disconnect', function() {
@@ -166,8 +167,8 @@ function drawNewCard(id, text, x, y, rot, colour, sticker, animationspeed) {
         ' draggable" style="-webkit-transform:rotate(' + rot +
         'deg);\
 	">\
-	<img src="/images/icons/token/Xion.png" class="card-icon delete-card-icon" />\
-	<img class="card-image" src="/images/' +
+	<img src="images/icons/token/Xion.png" class="card-icon delete-card-icon" />\
+	<img class="card-image" src="images/' +
         colour + '-card.png">\
 	<div id="content:' + id +
         '" class="content stickertarget droppable">' +
@@ -423,7 +424,7 @@ function drawNewColumn(columnName) {
         onblur: 'submit',
         width: '',
         height: '',
-        xindicator: '<img src="/images/ajax-loader.gif">',
+        xindicator: '<img src="images/ajax-loader.gif">',
         event: 'dblclick', //event: 'mouseover'
     });
 
@@ -525,7 +526,7 @@ function initColumns(columnArray) {
 
 function changeThemeTo(theme) {
     currentTheme = theme;
-    $("link[title=cardsize]").attr("href", "/css/" + theme + ".css");
+    $("link[title=cardsize]").attr("href", "css/" + theme + ".css");
 }
 
 
@@ -686,7 +687,7 @@ $(function() {
 
 
     if (boardInitialized === false)
-        blockUI('<img src="/images/ajax-loader.gif" width=43 height=11/>');
+        blockUI('<img src="images/ajax-loader.gif" width=43 height=11/>');
 
     //setTimeout($.unblockUI, 2000);
 

--- a/config.js
+++ b/config.js
@@ -6,8 +6,25 @@
 };
 */
 
+var argv = require('yargs')
+        .usage('Usage: $0 [--port INTEGER [8080]] [--baseurl STRING ["/"]] [--redis STRING:INT [127.0.0.1:6379]] [--gaEnabled] [--gaAccount STRING [UA-2069672-4]]')
+        .argv;
+
+exports.server = {
+	port: argv.port || 8080,
+	baseurl: argv.baseurl || '/'
+};
+
+exports.googleanalytics = {
+	enabled: argv['gaEnabled'] || true,
+	account: argv['gaAccount'] || "UA-2069672-4"
+};
+
+var redis_conf = argv.redis || '127.0.0.1:6379';
 exports.database = {
 	type: 'redis',
-	prefix: '#scrumblr#'
+	prefix: '#scrumblr#',
+	host: redis_conf.split(':')[0] || '127.0.0.1',
+	port: redis_conf.split(':')[1] || 6379
 };
 

--- a/config.js
+++ b/config.js
@@ -16,7 +16,7 @@ exports.server = {
 };
 
 exports.googleanalytics = {
-	enabled: argv['gaEnabled'] || true,
+	enabled: argv['gaEnabled'] || false,
 	account: argv['gaAccount'] || "UA-2069672-4"
 };
 

--- a/lib/data/redis.js
+++ b/lib/data/redis.js
@@ -1,4 +1,4 @@
-//var conf = require('../../config.js').database;
+var conf = require('../../config.js').database;
 
 var     redis = require("redis"),
   redisClient = null; //redis.createClient();
@@ -16,7 +16,8 @@ var REDIS_PREFIX = '#scrumblr#';
 
 
 var db = function(callback) {
-	redisClient = redis.createClient();
+	console.log('Opening redis connection to ' + conf.host + ':' + conf.port);
+	redisClient = redis.createClient(conf.port, conf.host, {});
 	redisClient.on("connect", function (err) {
 		callback();
 	});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "redis": "~0.12.1",
     "sanitizer": "~0.1.1",
     "simplesets": "~1.2.0",
-    "socket.io": "1.x"
+    "socket.io": "1.x",
+    "yargs": "~2.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -69,17 +69,13 @@ router.get('/', function(req, res) {
 router.get('/demo', function(req, res) {
 	res.render('index.jade', {
 		pageTitle: 'scrumblr - demo',
-		demo: true,
-		ga: ga.enabled,
-		gaAccount: ga.account
+		demo: true
 	});
 });
 
 router.get('/:id', function(req, res){
 	res.render('index.jade', {
-		pageTitle: ('scrumblr - ' + req.params.id),
-		ga: ga.enabled,
-		gaAccount: ga.account
+		pageTitle: ('scrumblr - ' + req.params.id)
 	});
 });
 

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ var	async = require('async');
 var sanitizer = require('sanitizer');
 var compression = require('compression');
 var express = require('express');
+var conf = require('./config.js').server;
+var ga = require('./config.js').googleanalytics;
 
 /**************
  LOCAL INCLUDES
@@ -24,27 +26,35 @@ var sids_to_user_names = [];
  SETUP EXPRESS
 **************/
 var app = express();
+var router = express.Router();
 
 app.use(compression());
-app.use(express.static(__dirname + '/client'));
+app.use(conf.baseurl, router);
+
+app.locals.ga = ga.enabled;
+app.locals.gaAccount = ga.account;
+
+router.use(express.static(__dirname + '/client'));
 
 var server = require('http').Server(app);
-var port = process.argv[2] || 8080;
-server.listen(port);
+server.listen(conf.port);
 
-console.log('Server running at http://127.0.0.1:' + port + '/');
+console.log('Server running at http://127.0.0.1:' + conf.port + '/');
 
 /**************
  SETUP Socket.IO
 **************/
-var io = require('socket.io')(server);
+var io = require('socket.io')(server, {
+	path: conf.baseurl == '/' ? '' : conf.baseurl + "/socket.io"
+});
+
 
 /**************
  ROUTES
 **************/
-app.get('/', function(req, res) {
+router.get('/', function(req, res) {
 	//console.log(req.header('host'));
-	url = req.header('host');
+	url = req.header('host') + req.baseUrl;
 
 	var connected = io.sockets.connected;
 	clientsCount = Object.keys(connected).length;
@@ -56,16 +66,20 @@ app.get('/', function(req, res) {
 });
 
 
-app.get('/demo', function(req, res) {
+router.get('/demo', function(req, res) {
 	res.render('index.jade', {
-			pageTitle: 'scrumblr - demo',
-			demo: true
+		pageTitle: 'scrumblr - demo',
+		demo: true,
+		ga: ga.enabled,
+		gaAccount: ga.account
 	});
 });
 
-app.get('/:id', function(req, res){
+router.get('/:id', function(req, res){
 	res.render('index.jade', {
-		pageTitle: ('scrumblr - ' + req.params.id)
+		pageTitle: ('scrumblr - ' + req.params.id),
+		ga: ga.enabled,
+		gaAccount: ga.account
 	});
 });
 
@@ -111,7 +125,6 @@ io.sockets.on('connection', function (client) {
 				break;
 
 			case 'joinRoom':
-
 				joinRoom(client, message.data, function(clients) {
 
 						client.json.send( { action: 'roomAccept', data: '' } );

--- a/views/home.jade
+++ b/views/home.jade
@@ -2,7 +2,7 @@ doctype html
 html(lang="en")
 	head
 		<!-- SCRIPTS -->
-		<link rel="stylesheet" type="text/css" href="/css/style.css" />
+		<link rel="stylesheet" type="text/css" href="css/style.css" />
 		<!-- FONTS -->
 		<link href='http://fonts.googleapis.com/css?family=Rock+Salt' rel='stylesheet' type='text/css'>
 		<link href='http://fonts.googleapis.com/css?family=Covered+By+Your+Grace' rel='stylesheet' type='text/css'>
@@ -56,4 +56,5 @@ body
 
 	<script type="text/javascript">function go() {var value = document.forms[0].elements["name"].value; value = escape(value); window.location.href = value; return false;}</script>
 
-	<script type="text/javascript">	  var _gaq = _gaq || []; _gaq.push(['_setAccount', 'UA-2069672-4']);  _gaq.push(['_trackPageview']);   (function() {    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);  })(); </script>
+	- if (locals.ga)
+		<script type="text/javascript">	  var _gaq = _gaq || []; _gaq.push(['_setAccount', '#{gaAccount}']);  _gaq.push(['_trackPageview']);   (function() {    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);  })(); </script>

--- a/views/index.jade
+++ b/views/index.jade
@@ -12,15 +12,15 @@ block body
 	div.board-outline
 		div#board
 			div#board-doodles
-			image#marker(src='/images/marker.png')
-			image#eraser(src='/images/eraser.png')
+			image#marker(src='images/marker.png')
+			image#eraser(src='images/eraser.png')
 
 
 			table#board-table.board-table
 				tr
 					td#icon-col(width='1%')
-						image#add-col.col-icon(width='20', height='20', src='/images/icons/iconic/raster/black/plus_alt_32x32.png')
-						image#delete-col.col-icon(width='20', height='20', src='/images/icons/iconic/raster/black/minus_alt_32x32.png')
+						image#add-col.col-icon(width='20', height='20', src='images/icons/iconic/raster/black/plus_alt_32x32.png')
+						image#delete-col.col-icon(width='20', height='20', src='images/icons/iconic/raster/black/minus_alt_32x32.png')
 
 
 	div.buttons
@@ -65,4 +65,5 @@ block body
 
 	//<div style="width: 980px; height: 450px; border: solid 2px; opacity:.1; margin-top: 100px"> this will be the backlog that only appears on drag or perhaps not at all</div>
 
-	<script type="text/javascript">	  var _gaq = _gaq || []; _gaq.push(['_setAccount', 'UA-2069672-4']);  _gaq.push(['_trackPageview']);   (function() {    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);  })(); </script>
+	- if (locals.ga)
+		<script type="text/javascript">	  var _gaq = _gaq || []; _gaq.push(['_setAccount', '#{gaAccount}']);  _gaq.push(['_trackPageview']);   (function() {    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);  })(); </script>

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -5,8 +5,8 @@ html(lang="en")
 		<!-- STYLES -->
 		<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
 
-		<link rel="stylesheet" type="text/css" href="/css/style.css" />
-		<link rel="stylesheet" title="cardsize" href="/css/bigcards.css" type="text/css" media="all" />
+		<link rel="stylesheet" type="text/css" href="css/style.css" />
+		<link rel="stylesheet" title="cardsize" href="css/bigcards.css" type="text/css" media="all" />
 
 		<!-- FONTS -->
 		<link href='//fonts.googleapis.com/css?family=Rock+Salt' rel='stylesheet' type='text/css'>
@@ -19,15 +19,15 @@ html(lang="en")
 		<script src="//code.jquery.com/ui/1.11.1/jquery-ui.js"></script>
 
 		<!-- External Scripts -->
-		<script src="/lib/jquery.ui.touch-punch.min.js"></script>
-		<script src="/lib/jquery.jeditable.js"></script>
-		<script src="/lib/jquery.blockUI.js"></script>
+		<script src="lib/jquery.ui.touch-punch.min.js"></script>
+		<script src="lib/jquery.jeditable.js"></script>
+		<script src="lib/jquery.blockUI.js"></script>
 
 		<!-- Socket.IO -->
-		<script src="/socket.io/socket.io.js"></script>
+		<script src="socket.io/socket.io.js"></script>
 
 		<!-- ** My Script ** -->
-		<script src="/script.js"></script>
+		<script src="script.js"></script>
 
 
 		title= locals.pageTitle


### PR DESCRIPTION
Hi,

I've made some changes to allow the app to work on non-root paths, to play nicely with Docker and allow configuration of the Google Analytics tag.

My changes allow the app to run under any base url which is configured either by altering `config.js` or passing a `--baseurl` argument through when running the app. The bulk of the changes are simple changing absolute references to relative references and a slight tweak to how the board name is retrieved from the inbound request url.

I've allowed the redis connection params to be set via config / runtime args so I can get things up and running inside Docker with a separate redis container linked; if it's of interest I'm running it as so;

```docker run -it --rm --name scrumblr --link redis-scrumblr:redis -p 8181:8181 scrumblr-app npm start -- --port 8181 --baseurl scrumblr --redis \$REDIS_PORT_6379_TCP_ADDR:\$REDIS_PORT_6379_TCP_PORT --gaEnabled --gaAccount ABC-123```

which then gets a healthy scrumblr app running and working when accessed as http://localhost/scrumblr/demo.

Thanks for the nice tool!

Tim