### PR TITLE
Fix support for MongoDB

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,11 +1,3 @@
-/*exports.database = {
-	type: 'mongodb',
-	hostname: 'localhost',
-	port: 27017,
-	database: 'scrumblr'
-};
-*/
-
 var argv = require('yargs')
         .usage('Usage: $0 [--port INTEGER [8080]] [--baseurl STRING ["/"]] [--redis STRING:INT [127.0.0.1:6379]] [--gaEnabled] [--gaAccount STRING [UA-2069672-4]]')
         .argv;
@@ -21,10 +13,21 @@ exports.googleanalytics = {
 };
 
 var redis_conf = argv.redis || '127.0.0.1:6379';
-exports.database = {
-	type: 'redis',
-	prefix: '#scrumblr#',
-	host: redis_conf.split(':')[0] || '127.0.0.1',
-	port: redis_conf.split(':')[1] || 6379
-};
 
+if (argv.use_mongo) {
+    console.log('Using MongoDB backend');
+    exports.database = {
+            type: 'mongodb',
+            hostname: 'localhost',
+            port: 27017,
+            database: 'scrumblr'
+    };
+} else {
+    console.log('Using Redis backend');
+    exports.database = {
+            type: 'redis',
+            prefix: '#scrumblr#',
+            host: redis_conf.split(':')[0] || '127.0.0.1',
+            port: redis_conf.split(':')[1] || 6379
+    };
+}

--- a/lib/data/mongodb.js
+++ b/lib/data/mongodb.js
@@ -19,6 +19,10 @@ var db = function(callback)
 	});
 }
 
+var DEFAULT_BOARD_WIDTH = 800;
+var DEFAULT_BOARD_HEIGHT = 600;
+var DEFAULT_THEME = 'bigcards';
+
 db.prototype = {
 	clearRoom: function(room, callback)
 	{
@@ -28,9 +32,11 @@ db.prototype = {
 	// theme commands
 	setTheme: function(room, theme)
 	{
+                theme |= DEFAULT_THEME;
 		this.rooms.update(
 			{name:room},
-			{$set:{theme:theme}}
+			{$set:{theme:theme}},
+                        {upsert:true}
 		);
 	},
 
@@ -39,9 +45,9 @@ db.prototype = {
 		this.rooms.findOne(
 			{name:room},
 			{theme:true},
-			function(err, room) {
-				if(room) {
-					callback(room.theme);
+			function(err, room_obj) {
+				if (room_obj) {
+					callback(room_obj.theme || DEFAULT_THEME);
 				} else {
 					callback();
 				}
@@ -102,11 +108,15 @@ db.prototype = {
 
 	getAllCards: function(room, callback)
 	{
-		this.rooms.findOne({name:room},{cards:true},function(err, room) {
-			if(room) {
-				callback(room.cards);
+		this.rooms.findOne({name:room},{cards:true},function(err, room_obj) {
+			if(room_obj) {
+                            var cards = [];
+                            for (var card_id in room_obj.cards) {
+                                cards.push(room_obj.cards[card_id]);
+                            }
+				callback(cards);
 			} else {
-				callback();
+				callback([]);
 			}
 		});
 	},
@@ -154,14 +164,17 @@ db.prototype = {
 	getBoardSize: function(room, callback) {
 		this.rooms.findOne(
 			{name:room},
-			function(err, room) {
-				if(room) {
-					callback(room.size);
+			function(err, room_obj) {
+				if(room_obj && room_obj.size) {
+					callback(room_obj.size);
 				} else {
-					callback();
+					callback({
+                                            width: DEFAULT_BOARD_WIDTH,
+                                            height: DEFAULT_BOARD_HEIGHT,
+                                        });
 				}
 			}
-		);		
+		);
 	},
 	setBoardSize: function(room, size) {
 		this.rooms.update(

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "compression": "^1.1.0",
     "express": "4.x",
     "jade": "~1.5.0",
+    "mongodb": "~2.0.x",
     "redis": "~0.12.1",
     "sanitizer": "~0.1.1",
     "simplesets": "~1.2.0",


### PR DESCRIPTION
Addresses issue #80.

Changes:

- Add package dependency. (Might be optional?)
- Add option `--use_mongodb` to prefer that backend over Redis. (A mandatory `--backend={mongodb|redis}` might be better?)
- Use defaults for theme and board size to prevent breaking UI with empty values. (Should be on a higher level but for some reason it works with Redis as is.)
- Return cards as a list of hashes instead of hash of hashes.
- Avoid shadowing incoming argument variables with values of a different type. (Ideally should be either extended to other functions for consistency or reverted if there's some reason for that like a JavaScript idiom.)