### PR TITLE
redis socket support

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,6 +22,7 @@ exports.googleanalytics = {
 
 var redis_conf = argv.redis || '127.0.0.1:6379';
 exports.database = {
+	sock: argv['sock'] || false,
 	type: 'redis',
 	prefix: '#scrumblr#',
 	host: redis_conf.split(':')[0] || '127.0.0.1',

--- a/lib/data/redis.js
+++ b/lib/data/redis.js
@@ -16,8 +16,13 @@ var REDIS_PREFIX = '#scrumblr#';
 
 
 var db = function(callback) {
-	console.log('Opening redis connection to ' + conf.host + ':' + conf.port);
-	redisClient = redis.createClient(conf.port, conf.host, {});
+	if (conf.sock) {
+		console.log('Opening redis connection to socket ' + conf.host);
+		redisClient = redis.createClient(conf.host);
+	} else {
+		console.log('Opening redis connection to ' + conf.host + ':' + conf.port);
+		redisClient = redis.createClient(conf.port, conf.host, {});
+	}
 	redisClient.on("connect", function (err) {
 		callback();
 	});


### PR DESCRIPTION
In order to enable socket support I added another command line argument: `--sock` which can be true or false. If set to true the `--redis` flag takes the path to the socket as argument.

Using the new feature a server start can look like this:
`node server.js --port 8080 --sock true --redis ~/.redis/sock`