### PR TITLE
Critical XSS fixes

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -192,32 +192,30 @@ function drawNewCard(id, text, x, y, rot, colour, type, sticker, animationspeed)
     var h = '';
 
     if (type == 'card' || type == null) {
-        h = '<div id="' + id + '" class="card ' + colour +
-            ' draggable cardstack" style="-webkit-transform:rotate(' + rot +
-            'deg);\
-        ">\
+        h = '<div class="card draggable cardstack">\
         <svg class="card-icon delete-card-icon" width="15" height="15"><use xlink:href="teenyicons/teenyicons-outline-sprite.svg#outline--x-circle" /></svg>\
-        <svg class="card-icon card-icon2 change-colour" data-colour="' + colour + '" width="15" height="15"><use xlink:href="teenyicons/teenyicons-outline-sprite.svg#outline--paintbrush" /></svg>\
-        <img class="card-image" src="images/' + colour + '-card.png">\
-        <div id="content:' + id +
-            '" class="content stickertarget droppable">' +
-            text + '</div><span class="filler"></span>\
+        <svg class="card-icon card-icon2 change-colour" width="15" height="15"><use xlink:href="teenyicons/teenyicons-outline-sprite.svg#outline--paintbrush" /></svg>\
+        <img class="card-image">\
+        <div class="content stickertarget droppable"></div><span class="filler"></span>\
         </div>';
     }
     else if (type == 'sticky') {
-         h = '<div id="' + id + '" class="sticky ' + colour +
-         ' draggable cardstack" style="-webkit-transform:rotate(' + rot +
-         'deg);\
-        ">\
+         h = '<div class="sticky draggable cardstack">\
         <svg class="card-icon delete-card-icon" width="15" height="15"><use xlink:href="teenyicons/teenyicons-outline-sprite.svg#outline--x-circle" /></svg>\
-        <img class="card-image" src="images/postit/p' + colour + '.png">\
-        <div id="content:' + id +
-            '" class="content stickertarget droppable">' +
-            text + '</div><span class="filler"></span>\
+        <img class="card-image">\
+        <div class="content stickertarget droppable"></div><span class="filler"></span>\
         </div>';
     }
 
     var card = $(h);
+    card.attr('id', id).addClass(colour).css('-webkit-transform', 'rotate(' + parseFloat(rot) + 'deg)');
+    card.children('.content').attr('id', 'content:' + id).text(text);
+    card.children('.change-colour').data('colour', colour);
+    if (type == 'card' || type == null) {
+        card.children('.card-image').attr('src', 'images/' + colour + '-card.png');
+    } else if (type == 'sticky') {
+        card.children('.card-image').attr('src', 'images/postit/p' + colour + '.png');
+    }
     card.appendTo('#board');
 
     //@TODO
@@ -387,13 +385,16 @@ function addSticker(cardId, stickerId) {
 
     if (Array.isArray(stickerId)) {
         for (var i in stickerId) {
-            stickerContainer.prepend('<img src="images/stickers/' + stickerId[i] +
-                '.png" class="stuck-sticker">');
+            stickerContainer.prepend(
+                $('<img class="stuck-sticker">').attr('src', 'images/stickers/' + stickerId[i] + '.png')
+            );
         }
     } else {
-        if (stickerContainer.html().indexOf(stickerId) < 0)
-            stickerContainer.prepend('<img src="images/stickers/' + stickerId +
-                '.png" class="stuck-sticker">');
+        if (stickerContainer.html().indexOf(stickerId) < 0) {
+            stickerContainer.prepend(
+                $('<img class="stuck-sticker">').attr('src', 'images/stickers/' + stickerId + '.png')
+            );
+        }
     }
 
     $(".stuck-sticker").draggable({
@@ -500,7 +501,9 @@ function drawNewColumn(columnName) {
 
     $('#icon-col').before('<td class="' + cls +
         '" width="10%" style="display:none"><h2 id="col-' + (totalcolumns + 1) +
-        '" class="editable column-editable">' + columnName + '</h2></td>');
+        '" class="editable column-editable"></h2></td>');
+
+    $('#col-' + (totalcolumns + 1)).text(columnName);
 
     $('.editable').editable({
         multiline: false,
@@ -606,8 +609,8 @@ function initColumns(columnArray) {
 
 
 function changeThemeTo(theme) {
-    currentTheme = theme;
-    $("link[title=cardsize]").attr("href", "css/" + theme + ".css");
+            currentTheme = theme;
+        $("link[title=cardsize]").attr("href", "css/" + theme + ".css");
 }
 
 
@@ -659,7 +662,7 @@ function displayUserJoined(sid, user_name) {
         name = sid.substring(0, 5);
 
 
-    $('#names-ul').append('<li id="user-' + sid + '">' + name + '</li>');
+    $('#names-ul').append($('<li>').attr('id', 'user-' + sid).text(name));
 }
 
 function displayUserLeft(sid) {


### PR DESCRIPTION
Thanks for the very quick response to the issue I created earlier, and sorry for my slower one!

`sanitizer` is currently being used to sanitize card content, but not to sanitize any other client-controlled values. As a result, cross-site scripting (XSS) is still possible through those other values.

# Example reproduction steps
1. Open any Scrumblr board
2. Open the browser console
3. Run the following JavaScript in the console:
  ```javascript
  createCard('xss', '', 0, 0, `0);" onmousemove="alert('XSS')" title="`, 'green', 'card');
  ```
  This creates an arbitrary card with a `rot` that escapes the `style` attribute and injects an `onmousemove` event handler on the card element. This event handler could be used to execute any arbitrary JavaScript code. `title="` is added at the end so that the following `"` is paired correctly.
4. Move the mouse over the card
5. An alert box with the message "XSS" will appear, confirming that the injected event handler was executed
6. Open the board as another user (e.g. in an incognito window) and move the mouse over the card to confirm that this is not just isolated to the user who created the card

Note that you could also inject more styles, such as to make the card take up the entire screen, to make the payload more impactful.

# What this PR fixes
To enable this PR to be merged as quickly as possible, I have only added sanitization client-side and to values that I was able to achieve XSS with (i.e. those that are directly rendered in the DOM).

Specifically, it sanitizes these values (in order of appearance in `script.js`):
- card ID
- rot
- card content
- card colour (only to prevent XSS, see below)
- stickerId (only to prevent XSS, see below)
- theme
- user name

# What this PR does not fix
I recommend also making the following changes involving sanitization of client-controlled values, but I don't believe these can be used to achieve XSS so they are not as critical and I have not included them in this PR.

- Also sanitize these values server-side, since it is generally best practice to sanitize untrusted input on both the client and server
  - Switch to a more robust sanitization library (such as DOMPurify) for server-side sanitization, since even the author of `sanitizer` does not recommend it, and it is no longer maintained
- Prepend a prefix to card IDs (e.g. `card-`) to prevent a malicious user from creating an ID that matches an existing DOM element's ID, which could corrupt the DOM
  - then, load the card element using `$(document.getElementById(cardId))` instead of `$('#' + cardId)`, to prevent a malicious user from create a card with special characters in its ID which would also cause unexpected behaviour since it could target elements *inside* the card element instead of the card element itself
- Validate that `colour` is in `cardColours` before loading the corresponding image, to prevent a malicious user from using an invalid colour which results in cards with a missing image
- Validate `stickerId` before loading the corresponding image, to prevent a malicious user from using an invalid stickerId which results in stickers with a missing image
- Validate `theme` before loading the corresponding CSS file, to prevent a malicious user from using an invalid theme which results in a missing CSS file and broken styling